### PR TITLE
Add container snapping

### DIFF
--- a/_readme/docs.md
+++ b/_readme/docs.md
@@ -7,7 +7,7 @@
 ### Markup Example
 
 ```jsx
-<ScrollContainer>
+<ScrollContainer snap="mandatory">
   <ScrollPage page={0}>
     <Animator animation={batch(Fade(), Sticky(), MoveOut(0, -200))}>
       <MediumText>Let't me show you scroll animation 😀</MediumText>
@@ -17,6 +17,8 @@
 ```
 
 - `ScrollContainer` must be root
+
+- `ScrollContainer`'s children snap option is optional (`'none' | 'mandatory' | 'proximity'`)
 
 - `ScrollContainer`'s children must be `ScrollPage`
 

--- a/src/ScrollContainer.tsx
+++ b/src/ScrollContainer.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { ScrollContainerContext } from "react-scroll-motion";
-import environment from "./environment";
+import { ScrollContainerContext } from "./ScrollContext";
+import environment from "./utils/environment";
 
 interface IProps {
   snap: string;

--- a/src/ScrollContainer.tsx
+++ b/src/ScrollContainer.tsx
@@ -3,7 +3,7 @@ import { ScrollContainerContext } from "./ScrollContext";
 import environment from "./utils/environment";
 
 interface IProps {
-  snap: string;
+  snap: 'none' | 'proximity' | 'mandatory';
   children: React.ReactNodeArray;
   scrollParent: Window | HTMLElement;
 }


### PR DESCRIPTION
This change adds the ability to define snapping rules similar to CSS snapping rules (https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-type). The following is an example on how to use the snapping. If the option is left blank, `'none'` is automatically assumed. This references and closes #10, which I posted earlier today.

Mandatory:
```jsx
<ScrollContainer snap="mandatory">
  ...
</ScrollContainer>
```

Proximity:
```jsx
<ScrollContainer snap="proximity">
  ...
</ScrollContainer>
```

None (Default):
```jsx
<ScrollContainer snap="none">
  ...
</ScrollContainer>
```
*OR*
```jsx
<ScrollContainer>
  ...
</ScrollContainer>
```