### PR TITLE
In typescript using batch gives an error

### DIFF
--- a/src/animations/AnimationTool.ts
+++ b/src/animations/AnimationTool.ts
@@ -5,7 +5,7 @@ type StyleValue = string | number | Function
 const callIfFunc = (value: StyleValue, ...params: any) =>
   typeof value === "function" ? value(...params) : value;
 
-export const batch = (...animations: [IAnimation]) => {
+export const batch = (...animations: IAnimation[]) => {
   const batched: IAnimation = { in: { style: {} }, out: { style: {} } };
   const batchedTransform: {
     in: (StyleValue)[];


### PR DESCRIPTION
I get this type error when I try to use batch with multiple animations
Type error: Expected 1 arguments, but got 2
I have proposed the change.
In my local, in the AnimationTool.d.ts file that gets created I have changed
export declare const batch: (animations_0: IAnimation) => IAnimation;
to
export declare const batch: ( ...animations: IAnimation[]) => IAnimation;
and tested

<img width="664" alt="image" src="https://user-images.githubusercontent.com/99466344/157452767-d5aefa29-9b3f-4d17-8b1d-6917521e87d3.png">
