### PR TITLE
In typescript using batch gives an error

### DIFF
--- a/src/animations/AnimationTool.ts
+++ b/src/animations/AnimationTool.ts
@@ -5,7 +5,7 @@ type StyleValue = string | number | Function
 const callIfFunc = (value: StyleValue, ...params: any) =>
   typeof value === "function" ? value(...params) : value;
 
-export const batch = (...animations: [IAnimation]) => {
+export const batch = (...animations: IAnimation[]) => {
   const batched: IAnimation = { in: { style: {} }, out: { style: {} } };
   const batchedTransform: {
     in: (StyleValue)[];


### PR DESCRIPTION
I get this type error when I try to use batch with multiple animations
Type error: Expected 1 arguments, but got 2.
![image](https://user-images.githubusercontent.com/35791871/157454113-e3f44eaf-6f64-49a9-a3db-37eca2fe6436.png)

In my local, in the AnimationTool.d.ts file that gets created I have changed
export declare const batch: (animations_0: IAnimation) => IAnimation;
to
export declare const batch: ( ...animations: IAnimation[]) => IAnimation;

Testing - 
have cloned your code, changed the above line, ran npm run build, took the dist folder, replaced it in the react project.
It is working perfectly.