### PR TITLE
Allow usage with other elements on the page.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   ],
   "private": false,
   "scripts": {
-    "build": "rimraf ./dist && npx tsc"
+    "build": "rimraf ./dist && npx tsc",
+    "prepare": "npm run build"
   },
   "peerDependencies": {
     "react": "^18.0.11",


### PR DESCRIPTION
I had a use case where I have to use the ScrollContainer on one part of my page instead of the whole page, so I have a structure like this: 
```jsx
<main>
  <SomeContent />
  <SomeMoreContent />

  <ScrollContainer>
    <ScrollPage />
    <ScrollPage />
  </ScrollContainer>

  <SomeMoreContent />
</main>
```

But that doesn't work as expected, because the individual page offsets are calculated from window.top and not from the ScrollContainer element. This results in the ScrollPages content appearing on top of my <SomeContent>.

This PR just makes it so the offsets are calculated from the ScrollContainer. this fixed my problem.
I'm creating this PR just in case if this is something you'd want to have by default, otherwise feel free to close it 😃.
